### PR TITLE
lib: remove the setup phase

### DIFF
--- a/lib/omniauth/proconnect.rb
+++ b/lib/omniauth/proconnect.rb
@@ -21,10 +21,6 @@ module OmniAuth
       option :post_logout_redirect_uri
       option :scope, "openid email given_name usual_name"
 
-      def setup_phase
-        discover_endpoint!
-      end
-
       def request_phase
         redirect(authorization_uri)
       end


### PR DESCRIPTION
It's unclear whether the setup phase was the right place to discover the endpoint but what's really tragic is that it doesn't actually store anything (whereas `discovered_configuration` is memoized) so that GET request was absolutely useless.