### PR TITLE
logout: pass along the client_id

### DIFF
--- a/lib/omniauth/proconnect.rb
+++ b/lib/omniauth/proconnect.rb
@@ -101,7 +101,8 @@ module OmniAuth
           endpoint.query = URI.encode_www_form(
             id_token_hint: session["omniauth.pc.id_token"],
             state: current_state,
-            post_logout_redirect_uri: options[:post_logout_redirect_uri]
+            post_logout_redirect_uri: options[:post_logout_redirect_uri],
+            client_id: options[:client_id]
           )
         end
       end


### PR DESCRIPTION
commit:

> the ID token is not always accessible : it might be stored in an expired cookie or other sad technicalities. ProConnect allows sending the `client_id` for these precise scenarios so send it along regardless (I assume ProConnect picks which one it prefers) to allow a proper logout.